### PR TITLE
Expose a type library, add `any` type

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,9 +72,13 @@ function Osom (schemaBlueprint, globalRules) {
 
     return reduce(schema, function applyRule (objSchema, rule, name) {
       var value = obj[name]
-      var hasValue = exists(value)
 
-      if ((rule.required && !hasValue) || (hasValue && !rule.casting && type(value) !== schemaTypes[name])) {
+      var hasValue = exists(value)
+      var isMissing = rule.required && !hasValue
+      var isAny = schemaTypes[name] === 'any'
+      var isMatch = type(value) === schemaTypes[name]
+
+      if (isMissing || (hasValue && !rule.casting && !isAny && !isMatch)) {
         throwTypeError(name, schemaTypes[name], rule.required)
       }
 
@@ -97,6 +101,16 @@ function Osom (schemaBlueprint, globalRules) {
   }
 
   return osom
+}
+
+Osom.types = {
+  any: function Any (value) { return value },
+  string: String,
+  number: Number,
+  boolean: Boolean,
+  date: Date,
+  array: Array,
+  object: Object
 }
 
 module.exports = Osom


### PR DESCRIPTION
I was looking for a way to allow any type for a value without having it be cast to something or other. I added an `any` type that's accessible by using `osom.types.any`. I also considered exposing them at the top-level, ie. `osom.any`, `osom.string` etc.

```javascript
let schema = {
  primary: osom.types.any
}

let validator = osom(schema)
validator({ primary: true }) // -> { primary: true }
validator({ primary: '38493' }) // -> { primary: '38493' }
validator({ primary: new Something() }) // -> { primary:  Something {}  }
```

The rest of the usual types are also accessible this way since I thought it should be universal. For example instead of:

```javascript
let schema = {
  name: String
}
```

You could do:

```javascript
let schema = {
  name: osom.types.string
}
```

Since this added another check to the type check line, I also split out a few helper variables to make that line a little less monstrous.

I tried to keep this simple since `osom` is a neat minimalist take on modelling. Let me know any thoughts!