### PR TITLE
Fix README.md typo. Fix `casting: false` behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ var schema = {
 var validator = osom(schema)
 
 // validate it!
-validator({age: '  23  '}) // => {age: '23'}
+validator({title: '  23  '}) // => {title: '23'}
 ```
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function Osom (schemaBlueprint, globalRules) {
       const isInvalidType = isCastingDisabled && !isSameType
       if (isInvalidType) throwTypeError(name, schemaTypes[name], rule.required)
 
-      if (rule.casting && hasValue) value = rule.type(obj[name])
+      if (hasValue) value = rule.casting ? rule.type(obj[name]) : obj[name]
       else if (rule.default) value = !isFunction(rule.default) ? rule.default : rule.default()
 
       // lodash.flow is buggy, this is a workaround (and dep-free)

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,18 @@ describe('schema defintion', function () {
       var validator = osom(schema)
       validator().should.be.eql({age: 23})
     })
+
+    it('based in a fn with precedence given to provided values', function () {
+      var rand = () => String(Math.random())
+      var schema = {
+        age: {
+          type: String, default: rand
+        }
+      }
+
+      var validator = osom(schema, { casting: false })
+      validator({ age: '23' }).should.be.eql({ age: '23' })
+    })
   })
 
   it('support transforms', function () {


### PR DESCRIPTION
This commit updates the first example to use the correct key `title` instead of `age`